### PR TITLE
activationEvents is deprecated

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "linter-perl",
   "linter-package": true,
-  "activationEvents": [],
   "main": "./lib/init",
   "version": "0.5.0",
   "description": "Lint perl on the fly, using perl (B::Lint)",


### PR DESCRIPTION
Use activationCommands instead of activationEvents.

But, activationCommands is optional.
So, I removed activationEvents which isn't used.

Please accept my pull request !!  I got sad to see warnings...

see: atom/atom@53b538311e85b2539e8709ef8dd44d8ab74e9bab
