### PR TITLE
Fix support for executablePath option. (Issue #28)

### DIFF
--- a/lib/linter-perl.coffee
+++ b/lib/linter-perl.coffee
@@ -113,8 +113,6 @@ module.exports = class LinterPerl
   # build a lint command from the current states.
   buildCommand: (filePath, rootDirectory) ->
     cmd = ["perl", "-MO=Lint"]
-	if @config.executablePath
-	  cmd[0] = @config.executablePath + "/perl"
 
     # perl -MO=Lint,all,...
     if @config.lintOptions
@@ -151,5 +149,9 @@ module.exports = class LinterPerl
     # plenv/perlbrew support
     if @config.executeCommandViaShell
       cmd = [process.env.SHELL, "-lc", cmd.join(" ")]
+
+    # support for executablePath
+    if @config.executablePath
+      cmd[0] = @config.executablePath + "/perl"
 
     cmd

--- a/lib/linter-perl.coffee
+++ b/lib/linter-perl.coffee
@@ -113,6 +113,8 @@ module.exports = class LinterPerl
   # build a lint command from the current states.
   buildCommand: (filePath, rootDirectory) ->
     cmd = ["perl", "-MO=Lint"]
+	if @config.executablePath
+	  cmd[0] = @config.executablePath + "/perl"
 
     # perl -MO=Lint,all,...
     if @config.lintOptions


### PR DESCRIPTION
I noticed some time ago that executablePath wasn't properly supported despite being an option.  I recently found that this was ticketed 6 months ago as #28.  I actually fixed this in my local checkout sometime ago, but a recent update re-broke my local changes, so I'm pushing upstream to get this fixed.  Thanks.